### PR TITLE
feat: 방향키 롱프레스 연속 이동 지원

### DIFF
--- a/app/src/main/kotlin/pe/aioo/openmoa/view/keyboardview/ArrowView.kt
+++ b/app/src/main/kotlin/pe/aioo/openmoa/view/keyboardview/ArrowView.kt
@@ -32,6 +32,11 @@ class ArrowView : ConstraintLayout {
 
     private lateinit var binding: ArrowViewBinding
     private var isSelecting = false
+    private var upKeyListener: RepeatKeyTouchListener? = null
+    private var downKeyListener: RepeatKeyTouchListener? = null
+    private var leftKeyListener: RepeatKeyTouchListener? = null
+    private var rightKeyListener: RepeatKeyTouchListener? = null
+    private var backspaceKeyListener: RepeatKeyTouchListener? = null
 
     private fun init() {
         inflate(context, R.layout.arrow_view, this)
@@ -64,13 +69,12 @@ class ArrowView : ConstraintLayout {
             copyKey.setOnTouchListener(
                 SimpleKeyTouchListener(context, SpecialKeyMessage(SpecialKey.COPY))
             )
-            upKey.setOnTouchListener(
-                FunctionalKeyTouchListener(context) {
-                    SpecialKeyMessage(
-                        if (isSelecting) SpecialKey.SELECT_ARROW_UP else SpecialKey.ARROW_UP
-                    )
-                }
-            )
+            upKeyListener = RepeatKeyTouchListener(context) {
+                SpecialKeyMessage(
+                    if (isSelecting) SpecialKey.SELECT_ARROW_UP else SpecialKey.ARROW_UP
+                )
+            }
+            upKey.setOnTouchListener(upKeyListener)
             cutKey.setOnTouchListener(
                 SimpleKeyTouchListener(context, SpecialKeyMessage(SpecialKey.CUT))
             )
@@ -87,26 +91,24 @@ class ArrowView : ConstraintLayout {
             selectAllKey.setOnTouchListener(
                 SimpleKeyTouchListener(context, SpecialKeyMessage(SpecialKey.SELECT_ALL))
             )
-            leftKey.setOnTouchListener(
-                FunctionalKeyTouchListener(context) {
-                    SpecialKeyMessage(
-                        if (isSelecting) SpecialKey.SELECT_ARROW_LEFT else SpecialKey.ARROW_LEFT
-                    )
-                }
-            )
+            leftKeyListener = RepeatKeyTouchListener(context) {
+                SpecialKeyMessage(
+                    if (isSelecting) SpecialKey.SELECT_ARROW_LEFT else SpecialKey.ARROW_LEFT
+                )
+            }
+            leftKey.setOnTouchListener(leftKeyListener)
             areaSelectKey.setOnTouchListener(
                 FunctionalKeyTouchListener(context) {
                     setSelectingOrToggleSelecting()
                     null
                 }
             )
-            rightKey.setOnTouchListener(
-                FunctionalKeyTouchListener(context) {
-                    SpecialKeyMessage(
-                        if (isSelecting) SpecialKey.SELECT_ARROW_RIGHT else SpecialKey.ARROW_RIGHT
-                    )
-                }
-            )
+            rightKeyListener = RepeatKeyTouchListener(context) {
+                SpecialKeyMessage(
+                    if (isSelecting) SpecialKey.SELECT_ARROW_RIGHT else SpecialKey.ARROW_RIGHT
+                )
+            }
+            rightKey.setOnTouchListener(rightKeyListener)
             endKey.setOnTouchListener(
                 FunctionalKeyTouchListener(context) {
                     SpecialKeyMessage(
@@ -117,19 +119,18 @@ class ArrowView : ConstraintLayout {
             deleteKey.setOnTouchListener(
                 SimpleKeyTouchListener(context, SpecialKeyMessage(SpecialKey.DELETE))
             )
-            downKey.setOnTouchListener(
-                FunctionalKeyTouchListener(context) {
-                    SpecialKeyMessage(
-                        if (isSelecting) SpecialKey.SELECT_ARROW_DOWN else SpecialKey.ARROW_DOWN
-                    )
-                }
-            )
+            downKeyListener = RepeatKeyTouchListener(context) {
+                SpecialKeyMessage(
+                    if (isSelecting) SpecialKey.SELECT_ARROW_DOWN else SpecialKey.ARROW_DOWN
+                )
+            }
+            downKey.setOnTouchListener(downKeyListener)
             pasteKey.setOnTouchListener(
                 SimpleKeyTouchListener(context, SpecialKeyMessage(SpecialKey.PASTE))
             )
-            backspaceKey.setOnTouchListener(
+            backspaceKeyListener =
                 RepeatKeyTouchListener(context, SpecialKeyMessage(SpecialKey.BACKSPACE))
-            )
+            backspaceKey.setOnTouchListener(backspaceKeyListener)
             languageKey.setOnTouchListener(
                 SimpleKeyTouchListener(context, SpecialKeyMessage(SpecialKey.LANGUAGE))
             )
@@ -143,6 +144,15 @@ class ArrowView : ConstraintLayout {
                 SimpleKeyTouchListener(context, SpecialKeyMessage(SpecialKey.ENTER))
             )
         }
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        upKeyListener?.endTimer()
+        downKeyListener?.endTimer()
+        leftKeyListener?.endTimer()
+        rightKeyListener?.endTimer()
+        backspaceKeyListener?.endTimer()
     }
 
 }

--- a/app/src/main/kotlin/pe/aioo/openmoa/view/keytouchlistener/RepeatKeyTouchListener.kt
+++ b/app/src/main/kotlin/pe/aioo/openmoa/view/keytouchlistener/RepeatKeyTouchListener.kt
@@ -9,26 +9,31 @@ import java.util.Timer
 
 class RepeatKeyTouchListener(
     context: Context,
-    private val key: BaseKeyMessage,
+    private val keyProvider: () -> BaseKeyMessage?,
 ) : BaseKeyTouchListener(context) {
 
+    constructor(context: Context, key: BaseKeyMessage) : this(context, { key })
+
+    @Volatile
     private var elapsed = 0L
-    private lateinit var timer: Timer
+    private var timer: Timer? = null
 
     private fun startTimer() {
+        endTimer()
         elapsed = 0L
-        sendKeyMessage(key)
+        keyProvider()?.let { sendKeyMessage(it) }
         timer = kotlin.concurrent.timer(period = config.longPressRepeatTime) {
             elapsed += config.longPressRepeatTime
             if (elapsed >= config.longPressThresholdTime) {
-                sendKeyMessage(key)
+                keyProvider()?.let { sendKeyMessage(it) }
             }
         }
     }
 
-    private fun endTimer() {
-        timer.cancel()
-        elapsed = 0
+    fun endTimer() {
+        timer?.cancel()
+        timer = null
+        elapsed = 0L
     }
 
     @SuppressLint("ClickableViewAccessibility")


### PR DESCRIPTION
@AiOO 안녕하세요. #12 에서 논의한 대로, 편의 기능과 분리해 독립적으로 머지하기 쉬운 코어 단위부터 작게 올립니다. 🙂

## 개요
방향키(상/하/좌/우)를 길게 누르면 커서가 연속 이동하도록 지원합니다. 기존에 backspace가 길게 누르면 반복 삭제되던 것과 동일한 사용감을 방향키에도 적용했습니다.

## 변경 사항
- 방향키 4개를 `RepeatKeyTouchListener`로 교체해 롱프레스 시 연속 이동
- `RepeatKeyTouchListener`가 키를 람다(`keyProvider`)로 받도록 변경 → 선택 모드(`SELECT_ARROW_*`)도 누르는 시점에 평가해 대응
- 고정 키 기존 호출부 호환용 보조 생성자 추가 (backspace 등 그대로 동작)
- `@Volatile` 및 `Timer?` 적용으로 타이머 누수와 스레드 가시성 문제 수정
- `ArrowView.onDetachedFromWindow()`에서 방향키·백스페이스 타이머 정리

## 테스트
- `./gradlew testDebugUnitTest` 통과 (기존 한글 엔진 테스트 회귀 없음)
- 실기기에서 방향키 롱프레스 연속 이동, 선택 모드 연속 이동, backspace 반복 삭제 동작 확인

UI/터치·타이머에 의존하는 코드라 별도 유닛 테스트는 추가하지 않았습니다 (프로젝트 기존 관례에 맞춤).
